### PR TITLE
install local babel-cli@6

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "virtex": "^0.1.7"
   },
   "devDependencies": {
+    "babel-cli": "^6.3.17",
     "babel-preset-es2015": "^6.1.2"
   }
 }


### PR DESCRIPTION
fixes error caused by having babel@5 globally installed:

```
$ npm install

> virtex-dom@0.1.21 prepublish /.../virtex-dom
> rm -rf lib && babel src --out-dir lib

ReferenceError: [BABEL] src/canSelectText.js: Unknown option: /.../virtex-dom/.babelrc.presets
```
